### PR TITLE
refactored if else statements for clarity and less checks

### DIFF
--- a/src/flask/sansio/blueprints.py
+++ b/src/flask/sansio/blueprints.py
@@ -354,10 +354,11 @@ class Blueprint(Scaffold):
             if bp_subdomain is None:
                 bp_subdomain = blueprint.subdomain
 
-            if state.subdomain is not None and bp_subdomain is not None:
-                bp_options["subdomain"] = bp_subdomain + "." + state.subdomain
-            elif bp_subdomain is not None:
-                bp_options["subdomain"] = bp_subdomain
+            if bp_subdomain is not None:
+                if state.subdomain is not None:
+                    bp_options["subdomain"] = bp_subdomain + "." + state.subdomain
+                else:
+                    bp_options["subdomain"] = bp_subdomain
             elif state.subdomain is not None:
                 bp_options["subdomain"] = state.subdomain
 


### PR DESCRIPTION
refactored unorganized if else statements mainly to reduce the number of comparisons that occur (useless to check some conditions if the first is not met). And also for clarity